### PR TITLE
add a clean and prepublish step for npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "lint-src": "./node_modules/.bin/eslint ./src",
     "lint-test": "./node_modules/.bin/eslint ./test",
     "lint": "npm run lint-src && npm run lint-test",
-    "test": "./node_modules/.bin/karma start --single-run"
+    "test": "./node_modules/.bin/karma start --single-run",
+    "clean": "rm -rf dist/*",
+    "prepublish": "npm run clean && npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
this way we can ensure that dist is always the latest build on npm. 